### PR TITLE
【Fixed】Feature/issue#22

### DIFF
--- a/app/controllers/concerns/action_restrictions.rb
+++ b/app/controllers/concerns/action_restrictions.rb
@@ -1,0 +1,17 @@
+module ActionRestrictions
+  extend ActiveSupport::Concern
+
+  def only_users
+    if pharmacy_signed_in?
+      flash[:alert] = I18n.t('flash.alert.user.only_users')
+      redirect_back(fallback_location: root_path)
+    end
+  end
+
+  def only_pharmacies
+    if user_signed_in?
+      flash[:alert] = I18n.t('flash.alert.pharmacy.only_pharmacies')
+      redirect_back(fallback_location: root_path)
+    end
+  end
+end

--- a/app/controllers/pharmacies/passwords_controller.rb
+++ b/app/controllers/pharmacies/passwords_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Pharmacies::PasswordsController < Devise::PasswordsController
+  include ActionRestrictions
+  before_action :only_pharmacies
+
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/pharmacies/registrations_controller.rb
+++ b/app/controllers/pharmacies/registrations_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Pharmacies::RegistrationsController < Devise::RegistrationsController
+  include ActionRestrictions
   before_action :configure_sign_up_params, only: [:create]
+  before_action :only_pharmacies
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up

--- a/app/controllers/pharmacies/sessions_controller.rb
+++ b/app/controllers/pharmacies/sessions_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Pharmacies::SessionsController < Devise::SessionsController
+  include ActionRestrictions
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :only_pharmacies
 
   # GET /resource/sign_in
   # def new

--- a/app/controllers/pharmacies_controller.rb
+++ b/app/controllers/pharmacies_controller.rb
@@ -1,5 +1,6 @@
 class PharmaciesController < ApplicationController
   before_action :set_pharmacy, except: [:index]
+  before_action :only_myself, except: %i[index show]
 
   def index
     @q = Pharmacy.ransack(params[:q])
@@ -43,5 +44,12 @@ class PharmaciesController < ApplicationController
 
   def set_pharmacy
     @pharmacy = Pharmacy.find(params[:id])
+  end
+
+  def only_myself
+    if @pharmacy != current_pharmacy
+      flash[:alert] = I18n.t('flash.alert.pharmacy.only_myself')
+      redirect_to root_path
+    end      
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  include ActionRestrictions
+  before_action :only_users
+
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  include ActionRestrictions
   before_action :configure_sign_up_params, only: [:create]
+  before_action :only_users
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  include ActionRestrictions
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :only_users
 
   # GET /resource/sign_in
   # def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,8 +46,8 @@ class UsersController < ApplicationController
 
   def only_myself
     if @user != current_user
-      flash[:alert] = I18n.t('flash.alert.user.only_for_myself')
-      redirect_to current_user
+      flash[:alert] = I18n.t('flash.alert.user.only_myself')
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,8 @@
 class UsersController < ApplicationController
   before_action :set_user, except: [:index]
-  before_action :only_myself, except: [:index]
+  before_action :only_myself, except: %i[index show]
   before_action :all_pharmacies, only: [:index]
+  before_action :myself_of_pharmacies, only: [:show]
 
   def index
     @gender_choices = {}
@@ -54,6 +55,13 @@ class UsersController < ApplicationController
   def all_pharmacies
     unless pharmacy_signed_in?
       flash[:alert] = I18n.t('flash.alert.pharmacy.all_pharmacies')
+      redirect_to root_path
+    end
+  end
+
+  def myself_of_pharmacies
+    unless @user == current_user || pharmacy_signed_in?
+      flash[:alert] = I18n.t('flash.alert.user.myself_or_pharmacies')
       redirect_to root_path
     end
   end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -9,12 +9,12 @@ ja:
         continue_edit: 続けてユーザー情報を設定してください。
         only_myself: 他人のデータの編集・削除などはできません。
         myself_or_pharmacies: 他人のデータの参照はできません。
-        only_users: ユーザーでログインした際にお使い頂けます。
+        only_users: 薬局をログアウトした際にお使い頂けます。
       pharmacy:
         continue_edit: 続けて薬局情報を設定してください。
         all_pharmacies: ユーザー検索は薬局のみ実施可能です。
         only_myself: 他の薬局のデータの編集・削除などはできません。
-        only_pharmacies: 薬局でログインした際にお使い頂けます。
+        only_pharmacies: ユーザーをログアウトした際にお使い頂けます。
   activerecord:
     attributes:
       pharmacy:

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -7,11 +7,13 @@ ja:
         failure:
           update: アカウントの編集ができませんでした。
         continue_edit: 続けてユーザー情報を設定してください。
-        only_myself: 他人のデータの参照・編集・削除などはできません。
+        only_myself: 他人のデータの編集・削除などはできません。
+        myself_or_pharmacies: 他人のデータの参照はできません。
         only_users: ユーザーでログインした際にお使い頂けます。
       pharmacy:
         continue_edit: 続けて薬局情報を設定してください。
         all_pharmacies: ユーザー検索は薬局のみ実施可能です。
+        only_myself: 他の薬局のデータの編集・削除などはできません。
         only_pharmacies: 薬局でログインした際にお使い頂けます。
   activerecord:
     attributes:

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -8,9 +8,11 @@ ja:
           update: アカウントの編集ができませんでした。
         continue_edit: 続けてユーザー情報を設定してください。
         only_myself: 他人のデータの参照・編集・削除などはできません。
+        only_users: ユーザーでログインした際にお使い頂けます。
       pharmacy:
         continue_edit: 続けて薬局情報を設定してください。
         all_pharmacies: ユーザー検索は薬局のみ実施可能です。
+        only_pharmacies: 薬局でログインした際にお使い頂けます。
   activerecord:
     attributes:
       pharmacy:


### PR DESCRIPTION
無効な処理を弾く実装をする

 自分の薬局以外のアカウントの編集・削除はできない
 薬局でログイン中はユーザーでログイン/サインアップなどできない
※薬局検索はログイン/非ログイン問わず全ての人が実施できる